### PR TITLE
Update details on G4 which contains TMS - make G4 optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Of course, we also appreciate it if you cite any overview/experimental papers re
 ### Changes not in a release
 - 2021-09-29: Add link to [WP6 submission server](http://sampl-submit.us-west-1.elasticbeanstalk.com/submit/SAMPL9-HG)  
 - 2021-10-30: Push deadline back to Nov. 15
+- 2021-11-08: Make WP6 G4 guest optional as it contains silicon
 
 ## Challenge construction
 

--- a/host_guest_instructions.md
+++ b/host_guest_instructions.md
@@ -1,5 +1,7 @@
 # SAMPL9 Detailed Host-Guest Instructions
 
+Please note, the guest **G4 in this challenge is optional**, as it contains silicon, which can make application of some methods orders of magnitude more difficult.
+
 ## Due date
 
 Due dates vary by challenge; refer to the main [README.md](https://github.com/samplchallenges/SAMPL9/blob/master/README.md) for exact dates.


### PR DESCRIPTION
G4 contains TMS, which can be a huge headache; this makes it optional